### PR TITLE
Add support for uneven node groups

### DIFF
--- a/src/zeroband/inference/shardcast_downloader.py
+++ b/src/zeroband/inference/shardcast_downloader.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 import multiprocessing as mp
+import os
 import time
 from pathlib import Path
-import os
 
 from shardcast import ClientNode
 

--- a/src/zeroband/training/envs.py
+++ b/src/zeroband/training/envs.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     WORLD_SIZE: int
     LOCAL_RANK: int
     LOCAL_WORLD_SIZE: int
+    NODE_GROUP_SIZES: list[int] | None
 
 
 _TRAINING_ENV_PARSERS = {
@@ -26,6 +27,7 @@ _TRAINING_ENV_PARSERS = {
     "WORLD_SIZE": int,
     "LOCAL_RANK": int,
     "LOCAL_WORLD_SIZE": int,
+    "NODE_GROUP_SIZES": lambda x: list(map(int, x.split(","))),
     **_BASE_ENV_PARSERS,
 }
 

--- a/src/zeroband/training/world_info.py
+++ b/src/zeroband/training/world_info.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 import torch
 
@@ -16,29 +16,66 @@ class WorldInfo:
     local_world_size: int
 
     def __init__(
-        self, rank: int | None = None, world_size: int | None = None, local_rank: int | None = None, local_world_size: int | None = None
+        self,
+        rank: int | None = None,
+        world_size: int | None = None,
+        local_rank: int | None = None,
+        local_world_size: int | None = None,
+        node_group_sizes: List[int] | None = None,
     ):
         """
         Initialize the WorldInfo object either manually or by parsing environment variables.
         """
-        self.rank = rank or envs.RANK
-        self.world_size = world_size or envs.WORLD_SIZE
-        self.local_rank = local_rank or envs.LOCAL_RANK
-        self.local_world_size = local_world_size or envs.LOCAL_WORLD_SIZE
+        self.rank = rank if rank is not None else envs.RANK
+        self.world_size = world_size if world_size is not None else envs.WORLD_SIZE
+
+        # Support uneven node groups via NODE_GROUP_SIZES env var or argument
+        self.node_group_sizes = node_group_sizes or envs.NODE_GROUP_SIZES
+
+        if self.node_group_sizes:
+            assert sum(self.node_group_sizes) == self.world_size, "NODE_GROUP_SIZES must sum to WORLD_SIZE"
+            cumulative = 0
+            for idx, size in enumerate(self.node_group_sizes):
+                if self.rank < cumulative + size:
+                    self.local_rank = self.rank - cumulative
+                    self.local_world_size = size
+                    self.node_idx = idx
+                    break
+                cumulative += size
+            else:
+                raise AssertionError("Rank out of range of NODE_GROUP_SIZES")
+            self.num_nodes = len(self.node_group_sizes)
+        else:
+            self.local_rank = local_rank if local_rank is not None else envs.LOCAL_RANK
+            self.local_world_size = local_world_size if local_world_size is not None else envs.LOCAL_WORLD_SIZE
+            self.num_nodes = self.world_size // self.local_world_size
+            self.node_idx = self.rank // self.local_world_size
+
         self.gpu_ids = envs.CUDA_VISIBLE_DEVICES or list(range(torch.cuda.device_count()))
         self._check_world_info()
         self.num_gpus = len(self.gpu_ids)
-        self.num_nodes = self.world_size // self.local_world_size
 
     def _check_world_info(self):
         assert 0 <= self.local_rank < self.local_world_size
         assert 0 <= self.rank < self.world_size
         assert self.local_world_size <= self.world_size
-        # TODO: This is only true if we have evenly distributed node groups, which is probably a fair assumption (maybe at some point we want to run uneven node groups for pipelined inference)
-        assert self.world_size % self.local_world_size == 0
+        if self.node_group_sizes is None:
+            assert self.world_size % self.local_world_size == 0
+        else:
+            assert sum(self.node_group_sizes) == self.world_size
+            assert self.node_group_sizes[self.node_idx] == self.local_world_size
 
     def __repr__(self):
-        return f"WorldInfo(world_size={self.world_size}, rank={self.rank}, local_rank={self.local_rank}, local_world_size={self.local_world_size}, num_nodes={self.num_nodes}, num_gpus={self.num_gpus}, gpu_ids={self.gpu_ids})"
+        return (
+            "WorldInfo("
+            f"world_size={self.world_size}, "
+            f"rank={self.rank}, "
+            f"local_rank={self.local_rank}, "
+            f"local_world_size={self.local_world_size}, "
+            f"num_nodes={self.num_nodes}, "
+            f"num_gpus={self.num_gpus}, "
+            f"gpu_ids={self.gpu_ids})"
+        )
 
     def json(self) -> Dict[str, int]:
         return {
@@ -55,12 +92,22 @@ _WORLD_INFO: WorldInfo | None = None
 
 
 def get_world_info(
-    rank: int | None = None, world_size: int | None = None, local_rank: int | None = None, local_world_size: int | None = None
+    rank: int | None = None,
+    world_size: int | None = None,
+    local_rank: int | None = None,
+    local_world_size: int | None = None,
+    node_group_sizes: List[int] | None = None,
 ) -> WorldInfo:
     """Returns the WorldInfo. If not initialized, it will initialize."""
     global _WORLD_INFO
     if _WORLD_INFO is None:
-        _WORLD_INFO = WorldInfo(rank=rank, world_size=world_size, local_rank=local_rank, local_world_size=local_world_size)
+        _WORLD_INFO = WorldInfo(
+            rank=rank,
+            world_size=world_size,
+            local_rank=local_rank,
+            local_world_size=local_world_size,
+            node_group_sizes=node_group_sizes,
+        )
     return _WORLD_INFO
 
 

--- a/tests/unit/training/test_world_info.py
+++ b/tests/unit/training/test_world_info.py
@@ -77,3 +77,15 @@ def test_init_with_invalid_local_rank(local_rank_world_size: tuple[int, int]):
     os.environ["LOCAL_WORLD_SIZE"] = str(world_size)
     with pytest.raises(AssertionError):
         get_world_info()
+
+
+def test_init_with_node_group_sizes():
+    os.environ["RANK"] = "3"
+    os.environ["WORLD_SIZE"] = "7"
+    os.environ["NODE_GROUP_SIZES"] = "2,3,2"
+    world_info = get_world_info()
+    assert world_info.world_size == 7
+    assert world_info.local_world_size == 3
+    assert world_info.local_rank == 1
+    assert world_info.num_nodes == 3
+    assert world_info == get_world_info()


### PR DESCRIPTION
## Summary
- parse optional `NODE_GROUP_SIZES` from the environment
- compute `WorldInfo` values using provided node group sizes
- expose `node_group_sizes` argument to `get_world_info`
- test uneven node group initialization
- fix import order flagged by ruff

## Testing
- `ruff check . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_68461db721688321aa2eaba655dfefc2